### PR TITLE
Upgrade bpp to v2

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           chrome-version: latest
       - name: Browser Plugin Publish
-        uses: plasmo-corp/bpp@v1
+        uses: PlasmoHQ/bpp@v2
         env:
           PUPPETEER_EXECUTABLE_PATH: /opt/hostedtoolcache/chromium/latest/x64/chrome
         with:


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. We also renamed our organization which is why that's different now!

The new version adds support for the Edge Web Store Add-Ons API and improved reliability.


⚠️ Heads up the schema's changed a bit ⚠️

Here's an updated representation: https://raw.githubusercontent.com/PlasmoHQ/bpp/v2/keys.schema.json
Here's an example: https://github.com/PlasmoHQ/bpp/blob/main/keys.template.json

